### PR TITLE
Set the cardigann port via ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 
 # environment variables
 ENV CONFIG_DIR=/config
+ENV CARDIGANN_PORT=5060
 
 # install build packages
 RUN \

--- a/root/etc/services.d/cardigann/run
+++ b/root/etc/services.d/cardigann/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc cardigann server
+	s6-setuidgid abc cardigann server --port=$CARDIGANN_PORT --bind="0.0.0.0"


### PR DESCRIPTION
Kubernetes unfortunately passes a lot of ENV variables to Cardigann, and one of them is picked up as the port, resulting in errors like
`cardigann: error: listen tcp: address 0.0.0.0:tcp://10.103.202.115:5060: too many colons in address, try --help`

This PR sets the port during the boot step of Cardigann