### PR TITLE
Eol

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
     DEV_DOCKERHUB_IMAGE = 'lsiodev/cardigann'
     PR_DOCKERHUB_IMAGE = 'lspipepr/cardigann'
     DIST_IMAGE = 'alpine'
-    MULTIARCH='true'
+    MULTIARCH='false'
     CI='true'
     CI_WEB='true'
     CI_PORT='5060'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Find us at:
 [![Build Status](https://ci.linuxserver.io/view/all/job/Docker-Pipeline-Builders/job/docker-cardigann/job/master/badge/icon?style=flat-square)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-cardigann/job/master/)
 [![](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/cardigann/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/cardigann/latest/index.html)
 
+THIS IMAGE IS DEPRECATED. We will no longer be making updates or rebuilding this image. The Dockerhub endpoint will stay online with the current tags for this software. We recommend current users switch to linuxserver/jackett.
 [Cardigann](https://github.com/cardigann/cardigann) a server for adding extra indexers to Sonarr, SickRage and CouchPotato via Torznab and TorrentPotato proxies. Behind the scenes Cardigann logs in and runs searches and then transforms the results into a compatible format.
 
 

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -18,7 +18,7 @@ repo_vars:
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/cardigann'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/cardigann'
   - DIST_IMAGE = 'alpine'
-  - MULTIARCH='true'
+  - MULTIARCH='false'
   - CI='true'
   - CI_WEB='true'
   - CI_PORT='5060'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -2,6 +2,7 @@ project_name: cardigann
 project_url: "https://github.com/cardigann/cardigann"
 project_logo: "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/cardigann.png"
 project_blurb: |
+  THIS IMAGE IS DEPRECATED. We will no longer be making updates or rebuilding this image. The Dockerhub endpoint will stay online with the current tags for this software. We recommend current users switch to linuxserver/jackett.
   [{{ project_name|capitalize }}]({{ project_url }}) a server for adding extra indexers to Sonarr, SickRage and CouchPotato via Torznab and TorrentPotato proxies. Behind the scenes Cardigann logs in and runs searches and then transforms the results into a compatible format.
 project_lsio_github_repo_url: "https://github.com/linuxserver/docker-{{ project_name }}"
 

--- a/root/etc/cont-init.d/90-config
+++ b/root/etc/cont-init.d/90-config
@@ -1,0 +1,21 @@
+#!/usr/bin/with-contenv bash
+
+echo '
+******************************************************
+******************************************************
+*                                                    *
+*                                                    *
+*          This image has been deprecated            *
+*                                                    *
+*           Use the currently supported              *
+*                                                    *
+*               linuxserver/jackett                  *
+*                                                    *
+*    https://hub.docker.com/r/linuxserver/jackett    *
+*                                                    *
+*   https://github.com/linuxserver/docker-jackett    *
+*                                                    *
+*                                                    *
+*                                                    *
+******************************************************
+******************************************************'


### PR DESCRIPTION
Up for debate, but the project is having trouble finding maintainers and we have not been able to upgrade the base OS for a bit due to the lack of updates in their npm/go deps: 
https://github.com/cardigann/cardigann/issues/372
This splash would push people to Jackett. 

Need to delete if merged: 
https://ci.linuxserver.io/job/External-Triggers/job/cardigann-external-trigger/
https://ci.linuxserver.io/job/External-Triggers/job/cardigann-external-trigger/
